### PR TITLE
Add PolymorphicComponentProps

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ export * from './lifecycle/hooks/useIsMountedState/useIsMountedState.js';
 export * from './lifecycle/hooks/useMount/useMount.js';
 export * from './lifecycle/hooks/useUnmount/useUnmount.js';
 export * from './nextjs/useIsomorphicLayoutEffect/useIsomorphicLayoutEffect.js';
+export * from './types/PolymorphicComponentProps/PolymorphicComponentProps.js';
 export * from './utils/arrayRef/arrayRef.js';
 export * from './utils/createTimeout/createTimeout.js';
 export * from './utils/isRefObject/isRefObject.js';

--- a/src/types/PolymorphicComponentProps/PolymorphicComponentProps.mdx
+++ b/src/types/PolymorphicComponentProps/PolymorphicComponentProps.mdx
@@ -1,0 +1,83 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title="Types / PolymorphicComponentProps" />
+
+# PolymorphicComponentProps
+
+A collection of generic types to help build strongly typed Polymorphic Components, consistently.
+
+`PolymorphicComponentProps` takes care of combining your Component's unique prop types with those of
+any HTML element or React Component you happen to be assigning to your Polymorphic Component. As an
+extra precaution, a check is performed to omit any "default" prop type from the chosen element that
+might conflict with one of the same name in your Component.
+
+## Usage
+
+```tsx
+type FooComponentProps<T extends ElementType> = PolymorphicComponentProps<
+  T,
+  { barProp: string | undefined }
+>;
+
+type FooComponent = <T extends ElementType>(props: FooComponentProps<T>) => ReactElement | null;
+
+export const Foo: FooComponent = <T extends ElementType>({
+  as: Component = 'div',
+  children,
+  ...otherProps
+}: FooComponentProps<T>) => {
+  return <Component {...otherProps}>{children}</Component>;
+};
+```
+
+The type `FooComponentProps` consists of `T` and any custom prop types you require for
+`<FooComponent />` (in this example, `barProp`). The types for `T` are derived from the element in
+the `as` prop:
+
+```tsx
+<FooComponent as="a" href="https://media.monks.com" barProp="baz">
+  This is a proper link
+</FooComponent>
+
+<FooComponent as="h1">
+  Foo as a heading: anything goes.
+</FooComponent>
+```
+
+So while two examples use the same FooComponent, their `FooComponent` types are not the same. They
+are derived from the types from their respective `<a />` and `<h1 />` elements.
+
+```tsx
+<FooComponent as="button" href="https://example.com">
+  This button will throw an error
+</FooComponent>
+
+<FooComponent as="button" onClick={() => console.log("Clicked")}>
+  This button is okay
+</FooComponent>
+```
+
+### Using Refs
+
+A Polymorphic Component with Refs can be typed with `PolymorphicComponentPropsWithRef` and
+`PolymorphicRef`:
+
+```tsx
+type FooComponentProps<T extends ElementType> = PolymorphicComponentPropsWithRef<
+  T,
+  { barProp: string | undefined }
+>;
+
+type FooComponent = <T extends ElementType>(props: FooComponentProps<T>) => ReactElement | null;
+
+export const Foo: FooComponent = <T extends ElementType>(
+  { as: Component = 'div', children, ...otherProps }: FooComponentProps<T>,
+  ref?: PolymorphicRef<T>,
+) => {
+  return (
+    <Component {...otherProps} ref={ref}>
+      {children}
+    </Component>
+  );
+};
+```

--- a/src/types/PolymorphicComponentProps/PolymorphicComponentProps.mdx
+++ b/src/types/PolymorphicComponentProps/PolymorphicComponentProps.mdx
@@ -19,7 +19,7 @@ type FooComponentProps<T extends ElementType> = PolymorphicComponentProps<
   { barProp: string | undefined }
 >;
 
-type FooComponent = <T extends ElementType>(props: FooComponentProps<T>) => ReactElement | null;
+type FooComponent = <T extends ElementType>(props: FooComponentProps<T>) => ReactNode | null;
 
 export const Foo: FooComponent = <T extends ElementType>({
   as: Component = 'div',
@@ -68,16 +68,18 @@ type FooComponentProps<T extends ElementType> = PolymorphicComponentPropsWithRef
   { barProp: string | undefined }
 >;
 
-type FooComponent = <T extends ElementType>(props: FooComponentProps<T>) => ReactElement | null;
+type FooComponent = <T extends ElementType>(props: FooComponentProps<T>) => ReactNode | null;
 
-export const Foo: FooComponent = <T extends ElementType>(
-  { as: Component = 'div', children, ...otherProps }: FooComponentProps<T>,
-  ref?: PolymorphicRef<T>,
-) => {
-  return (
-    <Component {...otherProps} ref={ref}>
-      {children}
-    </Component>
-  );
-};
+export const Foo: FooComponent = forwardRef(
+  <T extends ElementType>(
+    { as: Component = 'div', children, ...otherProps }: FooComponentProps<T>,
+    ref?: PolymorphicRef<T>,
+  ) => {
+    return (
+      <Component {...otherProps} ref={ref}>
+        {children}
+      </Component>
+    );
+  },
+);
 ```

--- a/src/types/PolymorphicComponentProps/PolymorphicComponentProps.mdx
+++ b/src/types/PolymorphicComponentProps/PolymorphicComponentProps.mdx
@@ -35,26 +35,26 @@ The type `FooComponentProps` consists of `T` and any custom prop types you requi
 the `as` prop:
 
 ```tsx
-<FooComponent as="a" href="https://media.monks.com" barProp="baz">
+<Foo as="a" href="https://media.monks.com" barProp="baz">
   This is a proper link
-</FooComponent>
+</Foo>
 
-<FooComponent as="h1">
+<Foo as="h1">
   Foo as a heading: anything goes.
-</FooComponent>
+</Foo>
 ```
 
 So while two examples use the same FooComponent, their `FooComponent` types are not the same. They
 are derived from the types from their respective `<a />` and `<h1 />` elements.
 
 ```tsx
-<FooComponent as="button" href="https://example.com">
+<Foo as="button" href="https://example.com">
   This button will throw an error
-</FooComponent>
+</Foo>
 
-<FooComponent as="button" onClick={() => console.log("Clicked")}>
+<Foo as="button" onClick={() => console.log("Clicked")}>
   This button is okay
-</FooComponent>
+</Foo>
 ```
 
 ### Using Refs

--- a/src/types/PolymorphicComponentProps/PolymorphicComponentProps.ts
+++ b/src/types/PolymorphicComponentProps/PolymorphicComponentProps.ts
@@ -5,21 +5,27 @@ import type {
   PropsWithChildren,
 } from 'react';
 
-/**
- * AsProp
+/*
+ * AsProp is a type based on the supplied as prop.
  */
-type AsProp<T extends ElementType> = { as?: T };
+type AsProp<Types extends ElementType> = { as?: Types };
 
-type PropsToOmit<T extends ElementType, P> = keyof (AsProp<T> & P);
+/*
+ * MergeAndOverride is a type that omits type keys from BaseTypes that are also present in OverrideProps.
+ */
+type MergeAndOverride<BaseTypes, OverrideProps> = Omit<BaseTypes, keyof OverrideProps> &
+  OverrideProps;
+
+export type PolymorphicRef<Types extends ElementType> = ComponentPropsWithRef<Types>['ref'];
 
 export type PolymorphicComponentProps<
-  T extends ElementType,
-  P = Record<string, never>,
-> = PropsWithChildren<P & AsProp<T>> & Omit<ComponentPropsWithoutRef<T>, PropsToOmit<T, P>>;
-
-export type PolymorphicRef<T extends ElementType> = ComponentPropsWithRef<T>['ref'];
+  BaseTypes extends ElementType,
+  OwnProps = Record<string, never>,
+> = PropsWithChildren<
+  MergeAndOverride<ComponentPropsWithoutRef<BaseTypes>, AsProp<BaseTypes> & OwnProps>
+>;
 
 export type PolymorphicComponentPropsWithRef<
-  T extends ElementType,
-  P = Record<string, never>,
-> = PolymorphicComponentProps<T, P> & { ref?: PolymorphicRef<T> };
+  BaseTypes extends ElementType,
+  OwnProps = Record<string, never>,
+> = PolymorphicComponentProps<BaseTypes, OwnProps> & { ref?: PolymorphicRef<BaseTypes> };

--- a/src/types/PolymorphicComponentProps/PolymorphicComponentProps.ts
+++ b/src/types/PolymorphicComponentProps/PolymorphicComponentProps.ts
@@ -6,26 +6,26 @@ import type {
 } from 'react';
 
 /**
- * AsProp is a type based on the supplied as prop.
+ * PropsFromAs is a type based on the supplied as prop.
  */
-type AsProp<Types extends ElementType> = { as?: Types };
+type PropsFromAs<Type extends ElementType> = { as?: Type };
 
 /**
  * MergeAndOverride is a type that omits type keys from BaseTypes that are also present in OverrideProps.
  */
-type MergeAndOverride<BaseTypes, OverrideProps> = Omit<BaseTypes, keyof OverrideProps> &
+type MergeAndOverride<BaseType, OverrideProps> = Omit<BaseType, keyof OverrideProps> &
   OverrideProps;
 
-export type PolymorphicRef<Types extends ElementType> = ComponentPropsWithRef<Types>['ref'];
+export type PolymorphicRef<Type extends ElementType> = ComponentPropsWithRef<Type>['ref'];
 
 export type PolymorphicComponentProps<
-  BaseTypes extends ElementType,
+  BaseType extends ElementType,
   OwnProps = Record<string, never>,
 > = PropsWithChildren<
-  MergeAndOverride<ComponentPropsWithoutRef<BaseTypes>, AsProp<BaseTypes> & OwnProps>
+  MergeAndOverride<ComponentPropsWithoutRef<BaseType>, PropsFromAs<BaseType> & OwnProps>
 >;
 
 export type PolymorphicComponentPropsWithRef<
-  BaseTypes extends ElementType,
+  BaseType extends ElementType,
   OwnProps = Record<string, never>,
-> = PolymorphicComponentProps<BaseTypes, OwnProps> & { ref?: PolymorphicRef<BaseTypes> };
+> = PolymorphicComponentProps<BaseType, OwnProps> & { ref?: PolymorphicRef<BaseType> };

--- a/src/types/PolymorphicComponentProps/PolymorphicComponentProps.ts
+++ b/src/types/PolymorphicComponentProps/PolymorphicComponentProps.ts
@@ -5,12 +5,12 @@ import type {
   PropsWithChildren,
 } from 'react';
 
-/*
+/**
  * AsProp is a type based on the supplied as prop.
  */
 type AsProp<Types extends ElementType> = { as?: Types };
 
-/*
+/**
  * MergeAndOverride is a type that omits type keys from BaseTypes that are also present in OverrideProps.
  */
 type MergeAndOverride<BaseTypes, OverrideProps> = Omit<BaseTypes, keyof OverrideProps> &

--- a/src/types/PolymorphicComponentProps/PolymorphicComponentProps.ts
+++ b/src/types/PolymorphicComponentProps/PolymorphicComponentProps.ts
@@ -1,0 +1,25 @@
+import type {
+  ComponentPropsWithoutRef,
+  ComponentPropsWithRef,
+  ElementType,
+  PropsWithChildren,
+} from 'react';
+
+/**
+ * AsProp
+ */
+type AsProp<T extends ElementType> = { as?: T };
+
+type PropsToOmit<T extends ElementType, P> = keyof (AsProp<T> & P);
+
+export type PolymorphicComponentProps<
+  T extends ElementType,
+  P = Record<string, never>,
+> = PropsWithChildren<P & AsProp<T>> & Omit<ComponentPropsWithoutRef<T>, PropsToOmit<T, P>>;
+
+export type PolymorphicRef<T extends ElementType> = ComponentPropsWithRef<T>['ref'];
+
+export type PolymorphicComponentPropsWithRef<
+  T extends ElementType,
+  P = Record<string, never>,
+> = PolymorphicComponentProps<T, P> & { ref?: PolymorphicRef<T> };


### PR DESCRIPTION
Adds a collection of generic types to help create strongly typed Polymorphic Components. 

This came up while creating a Polymorphic component(which was easy) and then having to define types without knowing in advance which element was going to be the basis (which was a hassle). These types should make the process less of a chore.

