### PR TITLE
Fix(useFlip): prevent registerPlugin from running on server

### DIFF
--- a/src/gsap/hooks/useFlip/useFlip.ts
+++ b/src/gsap/hooks/useFlip/useFlip.ts
@@ -3,7 +3,9 @@ import Flip from 'gsap/Flip';
 import { useEffect, useRef, type MutableRefObject } from 'react';
 import { unref, type Unreffable } from '../../../utils/unref/unref.js';
 
-gsap.registerPlugin(Flip);
+if (typeof window !== 'undefined') {
+  gsap.registerPlugin(Flip);
+}
 
 export function useFlip(
   ref: Unreffable<HTMLElement | null>,


### PR DESCRIPTION
I got the following error in a project using this hook.

```
web:dev:  ⨯ TypeError: gsap__WEBPACK_IMPORTED_MODULE_2__.registerPlugin is not a function
web:dev:     at eval (webpack-internal:///../../node_modules/.pnpm/@mediamonks+react-kit@1.0.1_react@18.2.0/node_modules/@mediamonks/react-kit/dist/gsap/hooks/useFlip/useFlip.js:14:35)
```

After inspecting other hooks I saw that the other hooks have a safeguard to prevent it from running on the server.

```
if (typeof window !== 'undefined') {
  gsap.registerPlugin(plugin);
}
```

This safeguard was missing for this hook so this PR is adding that to the useFlip hook.