### PR TITLE
Add prop additionalCloneCount to AutoFill component

### DIFF
--- a/src/components/AutoFill/AutoFill.mdx
+++ b/src/components/AutoFill/AutoFill.mdx
@@ -12,6 +12,7 @@ Repeats children to fill the parent element in given axis.
 ```ts
 interface AutoFillProps {
   children: ReadonlyArray<ReactNode>;
+  additionalCloneCount?: number; // Default: 0
   axis?: 'x' | 'y'; // Default: 'x'
 }
 

--- a/src/components/AutoFill/AutoFill.stories.tsx
+++ b/src/components/AutoFill/AutoFill.stories.tsx
@@ -60,6 +60,55 @@ export const Horizontal: Story = {
   },
 };
 
+export const HorizontalWithAdditionalCloneCount: Story = {
+  render() {
+    return (
+      <div
+        style={{
+          width: 520,
+          display: 'flex',
+          outline: '1px solid blue',
+        }}
+      >
+        <AutoFill axis="x" additionalCloneCount={1}>
+          <div
+            style={{
+              padding: 15,
+              flex: '0 1 auto',
+            }}
+          >
+            <div
+              style={{
+                width: 50,
+                height: 50,
+                outline: '1px solid red',
+              }}
+            />
+          </div>
+
+          <div
+            style={{
+              padding: 15,
+              flex: '0 1 auto',
+            }}
+          >
+            <div
+              style={{
+                width: 75,
+                height: 50,
+                outline: '1px solid yellow',
+              }}
+            />
+          </div>
+        </AutoFill>
+      </div>
+    );
+  },
+  args: {
+    children: <div />,
+  },
+};
+
 export const Vertical: Story = {
   render() {
     return (

--- a/src/components/AutoFill/AutoFill.tsx
+++ b/src/components/AutoFill/AutoFill.tsx
@@ -22,13 +22,18 @@ type AutoFillProps = {
   children:
     | ReactElement<AutoFillChildrenProps>
     | ReadonlyArray<ReactElement<AutoFillChildrenProps>>;
+  additionalCloneCount?: number;
   axis?: 'x' | 'y';
 };
 
 /**
  * Repeats children to fill the parent element in given axis.
  */
-export function AutoFill({ children, axis = 'x' }: AutoFillProps): ReactElement {
+export function AutoFill({
+  children,
+  additionalCloneCount = 0,
+  axis = 'x',
+}: AutoFillProps): ReactElement {
   const childrenRef = useRef<Array<unknown> | null>([]);
   const [repeatCount, setRepeatCount] = useState(0);
 
@@ -43,11 +48,15 @@ export function AutoFill({ children, axis = 'x' }: AutoFillProps): ReactElement 
     const { clientWidth: parentClientWidth, clientHeight: parentClientHeight } = parentElement;
 
     if (axis === 'x') {
-      setRepeatCount(Math.ceil(parentClientWidth / (offsetLeft + clientWidth)));
+      setRepeatCount(
+        Math.ceil(parentClientWidth / (offsetLeft + clientWidth)) + additionalCloneCount,
+      );
     } else {
-      setRepeatCount(Math.ceil(parentClientHeight / (offsetTop + clientHeight)));
+      setRepeatCount(
+        Math.ceil(parentClientHeight / (offsetTop + clientHeight)) + additionalCloneCount,
+      );
     }
-  }, [axis]);
+  }, [additionalCloneCount, axis]);
 
   useEffect(updateRepeatCount, [updateRepeatCount, children]);
   useEventListener(globalThis.window, 'resize', useRafCallback(updateRepeatCount));


### PR DESCRIPTION
For marquees it can be handy to clone more items then just filling up the screen. Therefor the additionalCloneCount option is added to have more control over this.