### PR TITLE
Allow null on useExposedAnimations

### DIFF
--- a/src/gsap/hooks/useExposedAnimations/useExposedAnimations.stories.tsx
+++ b/src/gsap/hooks/useExposedAnimations/useExposedAnimations.stories.tsx
@@ -2,6 +2,8 @@
 import gsap from 'gsap';
 import { useCallback, useEffect, useRef, useState, type ReactElement } from 'react';
 import { ensuredForwardRef } from '../../../hocs/ensuredForwardRef/ensuredForwardRef.js';
+import { useRefs } from '../../../hooks/useRefs/useRefs.js';
+import type { Refs } from '../../../hooks/useRefs/useRefs.types.js';
 import { arrayRef } from '../../../utils/arrayRef/arrayRef.js';
 import { useAnimation } from '../useAnimation/useAnimation.js';
 import { useExposeAnimation } from '../useExposeAnimation/useExposeAnimation.js';
@@ -140,6 +142,32 @@ export function RerenderTesting(): ReactElement {
         }}
       >
         Trigger rerender
+      </button>
+    </div>
+  );
+}
+
+export function WithUseRefsArray(): ReactElement {
+  const refs = useRefs<Refs<{ items: Array<HTMLDivElement> }>>();
+  const animations = useExposedAnimations(refs.items);
+
+  // eslint-disable-next-line no-console
+  console.log('useExposedAnimations', animations);
+
+  const onRestartButtonClick = useCallback(() => {
+    for (const animation of animations) {
+      animation.restart();
+    }
+  }, [animations]);
+
+  return (
+    <div>
+      {Array.from({ length: 3 }).map((_, index) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <ChildItem key={index} ref={arrayRef(refs.items, index)} />
+      ))}
+      <button type="button" onClick={onRestartButtonClick}>
+        Restart animations
       </button>
     </div>
   );

--- a/src/gsap/hooks/useExposedAnimations/useExposedAnimations.ts
+++ b/src/gsap/hooks/useExposedAnimations/useExposedAnimations.ts
@@ -6,7 +6,7 @@ import { animations } from '../../animations.js';
  * Hook to get animation from global animations map using given reference
  */
 export function useExposedAnimations(
-  target: Unreffable<ReadonlyArray<unknown>>,
+  target: Unreffable<ReadonlyArray<unknown> | null>,
 ): ReadonlyArray<gsap.core.Animation> {
   const [exposedAnimations, setExposedAnimations] = useState<ReadonlyArray<gsap.core.Animation>>(
     [],


### PR DESCRIPTION
When trying to use useExposedAnimations along with an array in useRefs we'd get a type error as useRefs values are possibly null.

Example error:
```
TS2345: Argument of type  RefObject<HTMLDivElement[] | null>  is not assignable to parameter of type  Unreffable<readonly unknown[]> 
Type  RefObject<HTMLDivElement[] | null>  is not assignable to type  RefObject<readonly unknown[]> 
Type  HTMLDivElement[] | null  is not assignable to type  readonly unknown[] 
Type  null  is not assignable to type  readonly unknown[] 
```

 This change allows null to be used on useExposedAnimations.

Changes:
- Allows null values on useExposedAnimations.
- Adds story example with useRefs and an array